### PR TITLE
Upgrade circuit version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/cep21/aimdcloser
 go 1.10
 
 require (
-	github.com/cep21/circuit/v3 v3.0.0
+	github.com/cep21/circuit/v3 v3.2.0
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 )


### PR DESCRIPTION
We are currently facing the below error when trying to install the package in our project.  

```
go get github.com/cep21/aimdcloser                                                                                                                            
go: github.com/cep21/aimdcloser upgrade => v0.1.0
go get: github.com/cep21/aimdcloser@v0.1.0 requires
        github.com/cep21/circuit/v3@v3.0.0 requires
        github.com/golangci/golangci-lint@v1.15.0 requires
        github.com/golangci/errcheck@v0.0.0-20181003203344-ef45e06d44b6: invalid pseudo-version: does not match version-control timestamp (2018-12-23T08:41:20Z)
```

Turns out the issue is primarily due to circuit v3.0.0.
```
go get github.com/cep21/circuit/v3@v3.0.0                                                                                          
go get: github.com/cep21/circuit/v3@v3.0.0 requires
        github.com/golangci/golangci-lint@v1.15.0 requires
        github.com/go-critic/go-critic@v0.0.0-20181204210945-ee9bf5809ead: invalid pseudo-version: does not match version-control timestamp (2019-02-10T22:04:43Z)
```

Hence,  upgrading the package version
